### PR TITLE
use getMatrixFactorizationLabels

### DIFF
--- a/pulsar/core/cluster_generator.R
+++ b/pulsar/core/cluster_generator.R
@@ -39,17 +39,5 @@ print (ncomp)
 pmf = prismaNMF(data, ncomp)
 
 #compute and write clusters to a file
-clusters = calcDatacluster(pmf)
-
-processed = filterDataByTestAndCor(data$unprocessed, 0.05, FALSE)
-if (inherits(processed$mat, "Matrix")) {
-    classes = calcClassForSparseMatrix(processed$mat)
-}else {
-    classes = sapply(1:ncol(processed$mat), function(colIndex) paste(which(processed$mat[, colIndex] == 1), collapse=" "))
-}
-classCount = table(classes)
-uniqueClasses = names(classCount)
-lines = sapply(names(data$remapper), function(x) colnames(data$data)[match(x, uniqueClasses)])
-lineClusters = sapply(lines, function(x) clusters[match(x, names(clusters))])
-names(lineClusters) = paste("line", 1:length(lineClusters), sep="")
-write.table(lineClusters, clusters_file, row.names=FALSE, col.names=FALSE)
+clusters = getMatrixFactorizationLabels(pmf)
+write.table(clusters, clusters_file, row.names=FALSE, col.names=FALSE)


### PR DESCRIPTION
## Purpose

Fix #20 .

## How to fix

This PR is refactoring #21 . #21 didn't use `getMatrixFactorizationLabels`, so This PR use `getMatrixFactorizationLabels` without change .cluster file data format.